### PR TITLE
Update run.yml to fix ents.plist not found

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Resign with entitlements
         run: |
+          curl -O https://raw.githubusercontent.com/itsnebulalol/carplayify/main/ents.plist
           curl -L -o ${{ github.workspace }}/ldid https://github.com/permasigner/ldid/releases/latest/download/ldid_linux_x86_64
           chmod +x ${{ github.workspace }}/ldid
           


### PR DESCRIPTION
Adding curl -O https://raw.githubusercontent.com/itsnebulalol/carplayify/main/ents.plist under run, downloads the ents.plist inside of the workflow allowing it to be used. Without this I'm experiencing: error ents.plist no such file or directory.